### PR TITLE
fbsを一つにマージ

### DIFF
--- a/cmake/flatbuffer.cmake
+++ b/cmake/flatbuffer.cmake
@@ -2,8 +2,7 @@ find_package(flatbuffers)
 
 # スキーマファイルのパスを複数指定
 set(SCHEMA_FILES
-    "${CMAKE_SOURCE_DIR}/examples/data/hcw.fbs"
-    "${CMAKE_SOURCE_DIR}/examples/data/vcw.fbs"
+    "${CMAKE_SOURCE_DIR}/src/FbxLibra/data/cw.fbs"
 )
 
 # 生成されるソースファイルの出力ディレクトリを指定

--- a/src/FbxLibra/CounterWeight/HierarchyCounterWeight.cpp
+++ b/src/FbxLibra/CounterWeight/HierarchyCounterWeight.cpp
@@ -8,7 +8,7 @@
 #include "../FlatBufferLoader.h"
 
 
-HierarchyCounterWeight::HierarchyCounterWeight(const FbxLibra::CounterWeight::Hierarchy * hierarchy) {
+HierarchyCounterWeight::HierarchyCounterWeight(const Weight::Hierarchy * hierarchy) {
     this->hierarchy = hierarchy;
 }
 

--- a/src/FbxLibra/CounterWeight/HierarchyCounterWeight.h
+++ b/src/FbxLibra/CounterWeight/HierarchyCounterWeight.h
@@ -6,17 +6,17 @@
 #define ALL_HIERARCHYCOUNTERWEIGHT_H
 
 #include <fbxsdk.h>
-#include "hcw_generated.h"
+#include "cw_generated.h"
 #include "CounterWeight.h"
 
 class HierarchyCounterWeight: public CounterWeight {
 
 public:
-    explicit HierarchyCounterWeight(const FbxLibra::CounterWeight::Hierarchy* hierarchy);
+    explicit HierarchyCounterWeight(const Weight::Hierarchy* hierarchy);
     [[nodiscard]] bool EqualCounterWeight(const CounterWeight& other) const override;
 
 private:
-    const FbxLibra::CounterWeight::Hierarchy* hierarchy;
+    const Weight::Hierarchy* hierarchy;
 };
 
 #endif //ALL_HIERARCHYCOUNTERWEIGHT_H

--- a/src/FbxLibra/CounterWeight/HierarchyCounterWeightFactory.h
+++ b/src/FbxLibra/CounterWeight/HierarchyCounterWeightFactory.h
@@ -8,14 +8,14 @@
 
 #include <fbxsdk.h>
 #include "CounterWeightFactory.h"
-#include "hcw_generated.h"
+#include "cw_generated.h"
 
 class HierarchyCounterWeightFactory: public CounterWeightFactory{
 private:
     CounterWeight* CreateCounterWeight(const std::filesystem::path& fbx_path) override;
     CounterWeight* LoadCounterWeight(const std::filesystem::path& weight_path) override;
-    flatbuffers::Offset<FbxLibra::CounterWeight::Node> CreateNode(FbxNode* pNode);
-    void IncludeNode(std::vector<flatbuffers::Offset<FbxLibra::CounterWeight::Node>>& nodes, FbxNode* pNode, int depth = 0);
+    flatbuffers::Offset<Weight::Node> CreateNode(FbxNode* pNode);
+    void IncludeNode(std::vector<flatbuffers::Offset<Weight::Node>>& nodes, FbxNode* pNode, int depth = 0);
 };
 
 

--- a/src/FbxLibra/CounterWeight/VertexCounterWeight.cpp
+++ b/src/FbxLibra/CounterWeight/VertexCounterWeight.cpp
@@ -6,7 +6,7 @@
 #include "../FlatBufferLoader.h"
 
 using namespace std;
-using namespace FbxLibra::CounterWeight;
+using namespace Weight;
 
 template<typename T>
 bool CompareFlatBuffersVector(const flatbuffers::Vector<T>* vec1, const flatbuffers::Vector<T>* vec2) {

--- a/src/FbxLibra/CounterWeight/VertexCounterWeight.h
+++ b/src/FbxLibra/CounterWeight/VertexCounterWeight.h
@@ -2,20 +2,20 @@
 #define ALL_VERTEXCOUNTERWEIGHT_H
 
 #include <fbxsdk.h>
-#include "vcw_generated.h"
+#include "cw_generated.h"
 #include "CounterWeight.h"
 
 class VertexCounterWeight: public CounterWeight {
 
 public:
-    explicit VertexCounterWeight(const FbxLibra::CounterWeight::Meshes* meshes);
+    explicit VertexCounterWeight(const Weight::Meshes* meshes);
     // C2512エラーで入れたデフォルトコンストラクタ。
     // 引数を指定しない場合のコンストラクタが必要らしい。
 	VertexCounterWeight() = default;
     [[nodiscard]] bool EqualCounterWeight(const CounterWeight& other) const override;
 	
 private:
-    const FbxLibra::CounterWeight::Meshes* meshes;
+    const Weight::Meshes* meshes;
 };
 
 #endif //ALL_VERTEXCOUNTERWEIGHT_H

--- a/src/FbxLibra/CounterWeight/VertexCounterWeightFactory.cpp
+++ b/src/FbxLibra/CounterWeight/VertexCounterWeightFactory.cpp
@@ -4,7 +4,7 @@
 #include "../FlatBufferLoader.h"
 
 using namespace std;
-using namespace FbxLibra::CounterWeight;
+using namespace Weight;
 
 CounterWeight* VertexCounterWeightFactory::CreateCounterWeight(const std::filesystem::path& fbx_path) {
 	FbxManager* manager = FbxManager::Create();
@@ -135,9 +135,9 @@ CounterWeight* VertexCounterWeightFactory::CreateCounterWeight(const std::filesy
 	auto mesh_nodes_offsets = builder->CreateVector(mesh_node_vector);
 	auto meshes_offsets = CreateMeshes(*this->builder, mesh_nodes_offsets);
 	//Finish serializing a buffer by writing the root offset.
-	FinishMeshesBuffer(*builder, meshes_offsets);
-
-	auto ne = GetMeshes(builder->GetBufferPointer());
+    this->builder->Finish(meshes_offsets);
+//	FinishMeshesBuffer(*builder, meshes_offsets);
+	auto ne = flatbuffers::GetRoot<Weight::Meshes>(builder->GetBufferPointer());
 
 	importer->Destroy();
 	scene->Destroy();
@@ -164,6 +164,6 @@ void VertexCounterWeightFactory::IncludeMeshNodes(FbxNode* node, std::vector<Fbx
 
 
 CounterWeight* VertexCounterWeightFactory::LoadCounterWeight(const std::filesystem::path& weight_path) {
-	auto weight = FlatBufferLoader::Load(weight_path.string().c_str(), GetMeshes);
+	auto weight = FlatBufferLoader::Load(weight_path.string().c_str(), flatbuffers::GetRoot<Weight::Meshes>);
 	return new VertexCounterWeight(weight);
 }

--- a/src/FbxLibra/CounterWeight/VertexCounterWeightFactory.h
+++ b/src/FbxLibra/CounterWeight/VertexCounterWeightFactory.h
@@ -4,7 +4,7 @@
 
 #include <fbxsdk.h>
 #include "CounterWeightFactory.h"
-#include "vcw_generated.h"
+#include "cw_generated.h"
 
 class VertexCounterWeightFactory : public CounterWeightFactory {
 private:

--- a/src/FbxLibra/data/cw.fbs
+++ b/src/FbxLibra/data/cw.fbs
@@ -1,0 +1,65 @@
+namespace Weight;
+
+struct Vector2 {
+    x:double;
+    y:double;
+}
+
+struct Vector3 {
+    x:double;
+    y:double;
+    z:double;
+}
+
+struct Vector4 {
+    x:double;
+    y:double;
+    z:double;
+    w:double;
+}
+
+table Transform {
+    position: Vector3;
+    rotation: Vector3;
+    scale: Vector3;
+}
+
+table Node {
+    name: string;
+    transform: Transform;
+}
+
+table Hierarchy {
+    nodes: [Node];
+}
+
+table UV {
+    uv: [Vector2];
+}
+
+table Color {
+    r: float;
+    g: float;
+    b: float;
+    a: float;
+}
+
+table Mesh {
+    positions: [Vector3];
+    uvs: [Vector2];
+    indices: [int];
+    normals: [Vector3];
+}
+
+table MeshNode {
+    name: string;
+    transform: Transform;
+    mesh: Mesh;
+}
+
+table Meshes {
+    nodes: [MeshNode];
+}
+
+// root_type Hierarchy;
+// root_type Meshes;


### PR DESCRIPTION
## やったこと
- fbsを一つに統合
- fbsのネームスペースがFbxlibra::CounterWeightと長くなっていたので、Weightに変更
- 複数のデータを一つのfbsにした事でroot_typeが使えなくなったので、記載方法を変更