### PR TITLE
今後のためにバイトサイズ比較機能を基底のCounterWeight側に移動

### DIFF
--- a/src/FbxLibra/CounterWeight/CounterWeight.h
+++ b/src/FbxLibra/CounterWeight/CounterWeight.h
@@ -10,6 +10,15 @@
 #include "../Status.h"
 #include <filesystem>
 
+template<typename T>
+bool CompareFlatBuffersVector(const flatbuffers::Vector<T>* vec1, const flatbuffers::Vector<T>* vec2) {
+    if (vec1->size() != vec2->size()) {
+        return false;
+    }
+    // memcmpで連続メモリのByte差分の比較をする
+    return std::memcmp(vec1->Data(), vec2->Data(), vec1->size() * sizeof(T)) == 0;
+}
+
 class CounterWeight {
 public:
     /* @fn

--- a/src/FbxLibra/CounterWeight/VertexCounterWeight.cpp
+++ b/src/FbxLibra/CounterWeight/VertexCounterWeight.cpp
@@ -8,15 +8,6 @@
 using namespace std;
 using namespace Weight;
 
-template<typename T>
-bool CompareFlatBuffersVector(const flatbuffers::Vector<T>* vec1, const flatbuffers::Vector<T>* vec2) {
-	if (vec1->size() != vec2->size()) {
-		return false;
-	}
-	// memcmpで連続メモリのByte差分の比較をする
-	return std::memcmp(vec1->Data(), vec2->Data(), vec1->size() * sizeof(T)) == 0;
-}
-
 VertexCounterWeight::VertexCounterWeight(const Meshes* meshes) {
 	this->meshes = meshes;
 }


### PR DESCRIPTION
## やったこと
- VertexCounterWeight側に存在していた比較機能をConterWeight側に移動

## 理由
今後SkinWeightの比較がバイナリーサイズ比較で問題なさそうなので、より汎用的につける場所に移動
