### PR TITLE
fbx周りの取り扱いを共通Client化

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ include(cmake/flatbuffer.cmake)
 
 add_subdirectory(examples/EncodeSample)
 add_subdirectory(examples/DecodeSample)
+add_subdirectory(examples/FbxSample)
 add_subdirectory(src/FbxLibra)
 add_dependencies(FbxLibra generate_flatbuffers_code)
 

--- a/src/FbxLibra/CMakeLists.txt
+++ b/src/FbxLibra/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SOURCE_FILES
         main.cpp
         Status.h
         FlatBufferLoader.h
+        FbxClient.h
         FBXLibra.h
         FBXLibra.cpp
         CounterWeight/HierarchyCounterWeight.h

--- a/src/FbxLibra/CounterWeight/SkinWeightCounterWeightFactory.cpp
+++ b/src/FbxLibra/CounterWeight/SkinWeightCounterWeightFactory.cpp
@@ -9,22 +9,20 @@
 #include "../FlatBufferLoader.h"
 #include "cw_generated.h"
 #include "SkinWeightCounterWeight.h"
+#include "../FbxClient.h"
+#include "fbxsdk.h"
+
 
 CounterWeight *SkinWeightCounterWeightFactory::CreateCounterWeight(const std::filesystem::path &fbx_path) {
-    FbxManager* manager = FbxManager::Create();
-    FbxIOSettings* ios = FbxIOSettings::Create(manager, IOSROOT);
-    manager->SetIOSettings(ios);
-
-    FbxImporter* importer = FbxImporter::Create(manager, "");
-    if (!importer->Initialize(fbx_path.string().c_str(), -1, manager->GetIOSettings())) {
-        std::cerr << "Failed to initialize FBX importer: " << importer->GetStatus().GetErrorString() << std::endl;
-        return nullptr;
+    FbxClient client;
+    if (!client.Load(fbx_path))
+    {
+        std::cerr << "Failed to load FBX file: " << fbx_path << std::endl;
+        return  nullptr;
     }
-    FbxScene* scene = FbxScene::Create(manager, "Scene");
-    importer->Import(scene);
 
     std::vector<flatbuffers::Offset<Weight::SkinWeight>> skinWeightList;
-    FbxNode* rootNode = scene->GetRootNode();
+    FbxNode* rootNode = client.GetRootNode();
     if (rootNode)
     {
         ProcessNode(rootNode, skinWeightList);

--- a/src/FbxLibra/FbxClient.h
+++ b/src/FbxLibra/FbxClient.h
@@ -1,0 +1,51 @@
+﻿#ifndef FBXCLIENT_H
+#define FBXCLIENT_H
+#include <filesystem>
+#include <iostream>
+
+#include "fbxsdk.h"
+
+class FbxClient {
+private:
+    FbxNode* root;
+
+    // RAII(Resource Acquisition Is Initialization)を利用してFbxManager, FbxIOSettings, FbxSceneを破棄する
+    static void DestroyFbxManager(FbxManager* manager) { manager->Destroy(); }
+    static void DestroyFbxIOSettings(FbxIOSettings* ios) { ios->Destroy(); }
+    static void DestroyFbxScene(FbxScene* scene) { scene->Destroy(); }
+
+public:
+    FbxClient(): root(nullptr),
+                 manager(FbxManager::Create(), DestroyFbxManager),
+                 ios(FbxIOSettings::Create(manager.get(), IOSROOT), DestroyFbxIOSettings),
+                 scene(FbxScene::Create(manager.get(), "Scene"), DestroyFbxScene){}
+
+    std::unique_ptr<FbxManager, void(*)(FbxManager*)> manager;
+    std::unique_ptr<FbxIOSettings, void(*)(FbxIOSettings*)> ios;
+    std::unique_ptr<FbxScene, void(*)(FbxScene*)> scene;
+    bool Load(const std::filesystem::path& fbx_path)
+    {
+        manager->SetIOSettings(ios.get());
+        if (!manager || !ios || !scene) {
+            std::cerr << "Failed to create FbxManager, FbxIOSettings, or FbxScene." << std::endl;
+            return false;
+        }
+
+        FbxImporter* importer = FbxImporter::Create(manager.get(), "");
+
+        if (!importer->Initialize(fbx_path.string().c_str(), -1, manager->GetIOSettings())){
+            std::cerr << "Failed to initialize FBX importer: " << importer->GetStatus().GetErrorString() << std::endl;
+            return false;
+        }
+        importer->Import(scene.get());
+        importer->Destroy();
+
+        root = scene->GetRootNode();
+        return true;
+    };
+    [[nodiscard]] FbxNode* GetRootNode() const { return root; }
+};
+
+
+
+#endif //FBXCLIENT_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ configure_file(
 
 add_executable(${PROJECT_NAME}
     ../src/FbxLibra/Status.h
+    ../src/FbxLibra/FbxClient.h
     ../src/FbxLibra/FlatBufferLoader.h
     ../src/FbxLibra/FBXLibra.h
     ../src/FbxLibra/FBXLibra.cpp


### PR DESCRIPTION
## やったこと
- Fbxを取り扱っている部分を共通のClient化

## 利点
- 内部が全てスマートポインター化されてるので、わざわざDestroy()がいらない
- ヘッダーオンリーなので、分離しやすい

## 難点
無駄にClientが複雑